### PR TITLE
Add otserv flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Generate or Parse Tibia Flags to use
 
 ## Supported Versions
-* Tested only [TFS 1.0](https://github.com/otland/forgottenserver/)
+* Tested on [TFS 1.0](https://github.com/otland/forgottenserver/) and [Open Tibia Server](https://github.com/opentibia/server/)
 
 ## API
   * getFlagsByNumber(flag)

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -271,6 +271,13 @@
 	"desc": "Can answer rule violations",
 	"value": "274877906944",
 	"cat": "privileges"
+  },
+
+  {
+    "name": "PlayerFlag_CanReloadContent",
+	"desc": "Can reload server content",
+	"value": "549755813888",
+	"cat": "privileges"
   }
 
 ]

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -292,6 +292,13 @@
 	"desc": "Has infinite stamina",
 	"value": "2199023255552",
 	"cat": "privileges"
+  },
+
+  {
+    "name": "PlayerFlag_CannotMoveItems",
+	"desc": "Can not move items",
+	"value": "4398046511104",
+	"cat": "limitations"
   }
 
 ]

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -320,6 +320,13 @@
 	"desc": "Can see special description (uid, position...)",
 	"value": "35184372088832",
 	"cat": "privileges"
+  },
+
+  {
+    "name": "PlayerFlag_CannotBeSeen",
+	"desc": "Can not be seen (completely invisible)",
+	"value": "70368744177664",
+	"cat": "privileges"
   }
 
 ]

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -306,6 +306,13 @@
 	"desc": "Can not move creatures (including players)",
 	"value": "8796093022208",
 	"cat": "limitations"
+  },
+
+  {
+    "name": "PlayerFlag_CanReportBugs",
+	"desc": "Can file bug reports",
+	"value": "17592186044416",
+	"cat": "privileges"
   }
 
 ]

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -278,6 +278,13 @@
 	"desc": "Can reload server content",
 	"value": "549755813888",
 	"cat": "privileges"
+  },
+
+  {
+    "name": "PlayerFlag_ShowGroupInsteadOfVocation",
+	"desc": "Show player group instead of vocation",
+	"value": "1099511627776",
+	"cat": "privileges"
   }
 
 ]

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -313,6 +313,13 @@
 	"desc": "Can file bug reports",
 	"value": "17592186044416",
 	"cat": "privileges"
+  },
+
+  {
+    "name": "PlayerFlag_CanSeeSpecialDescription",
+	"desc": "Can see special description (uid, position...)",
+	"value": "35184372088832",
+	"cat": "privileges"
   }
 
 ]

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -285,6 +285,13 @@
 	"desc": "Show player group instead of vocation",
 	"value": "1099511627776",
 	"cat": "privileges"
+  },
+
+  {
+    "name": "PlayerFlag_HasInfiniteStamina",
+	"desc": "Has infinite stamina",
+	"value": "2199023255552",
+	"cat": "privileges"
   }
 
 ]

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -299,6 +299,13 @@
 	"desc": "Can not move items",
 	"value": "4398046511104",
 	"cat": "limitations"
+  },
+
+  {
+    "name": "PlayerFlag_CannotMoveCreatures",
+	"desc": "Can not move creatures (including players)",
+	"value": "8796093022208",
+	"cat": "limitations"
   }
 
 ]

--- a/lib/data/flags.json
+++ b/lib/data/flags.json
@@ -264,6 +264,13 @@
     "desc": "Permanent premium account",
     "value": "137438953472",
     "cat": "privileges"
+  },
+
+  {
+    "name": "PlayerFlag_CanAnswerRuleViolations",
+	"desc": "Can answer rule violations",
+	"value": "274877906944",
+	"cat": "privileges"
   }
 
 ]


### PR DESCRIPTION
Flags missing were [those ones](https://github.com/opentibia/server/blob/master/src/const.h#L989-L997) from [opentibia/server](https://github.com/opentibia/server). They are compatible with TFS.